### PR TITLE
Basic implementation of the time-line display for ThreadRecorder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@
 /heapstats-analyzer/build/
 /heapstats-analyzer/dist/
 /heapstats-analyzer/build
+.idea/
+*.ipr
+*.iws
+*.iml
+out/
+.idea_modules/
+atlassian-ide-plugin.xml
+com_crashlytics_export_strings.xml

--- a/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/ThreadRecorderController.java
+++ b/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/ThreadRecorderController.java
@@ -5,11 +5,6 @@
  */
 package jp.co.ntt.oss.heapstats.plugin.builtin.threadrecorder;
 
-import java.io.File;
-import java.net.URL;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.stream.Collectors;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
@@ -17,11 +12,7 @@ import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
-import javafx.scene.control.TextField;
+import javafx.scene.control.*;
 import javafx.scene.control.cell.CheckBoxTableCell;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.stage.FileChooser;
@@ -33,33 +24,58 @@ import jp.co.ntt.oss.heapstats.utils.HeapStatsUtils;
 import jp.co.ntt.oss.heapstats.utils.TaskAdapter;
 import jp.co.ntt.oss.heapstats.utils.ThreadStatConverter;
 
+import java.io.File;
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javafx.geometry.Orientation;
+import javafx.scene.Node;
+
 /**
  * FXML Controller class
  *
  * @author Yasu
  */
 public class ThreadRecorderController extends PluginController implements Initializable {
-    
+
+    private static final int TIMELINE_PADDING = 8;
+
+    private static final double DEFAULT_COLUMN_WIDTH = 525.0;
+
     @FXML
     private Button openBtn;
-    
+
     @FXML
     private TextField fileNameBox;
-    
+
     @FXML
     private ComboBox<ThreadStat> startCombo;
-    
+
     @FXML
     private ComboBox<ThreadStat> endCombo;
-    
+
     @FXML
-    private TableView<ThreadShowSwitch> threadListView;
-    
+    private TableView<ThreadStatViewModel> threadListView;
+
     @FXML
-    private TableColumn<ThreadShowSwitch, Boolean> showColumn;
-    
+    private TableColumn<ThreadStatViewModel, Boolean> showColumn;
+
     @FXML
-    private TableColumn<ThreadShowSwitch, String> threadNameColumn;
+    private TableColumn<ThreadStatViewModel, String> threadNameColumn;
+
+    @FXML
+    private TableView<ThreadStatViewModel> timelineView;
+
+    @FXML
+    private TableColumn<ThreadStatViewModel, List<ThreadStat>> timelineColumn;
+
+    private boolean boundScrollBar = false;
 
     /**
      * Initializes the controller class.
@@ -67,15 +83,27 @@ public class ThreadRecorderController extends PluginController implements Initia
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         startCombo.setConverter(new ThreadStatConverter());
+        startCombo.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            updateTime(newValue.getTime(), true);
+        });
         endCombo.setConverter(new ThreadStatConverter());
+        endCombo.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            updateTime(newValue.getTime(), false);
+        });
         
         showColumn.setCellValueFactory(new PropertyValueFactory<>("show"));
         showColumn.setCellFactory(CheckBoxTableCell.forTableColumn(showColumn));
         threadNameColumn.setCellValueFactory(new PropertyValueFactory<>("name"));
+        timelineColumn.setCellValueFactory(new PropertyValueFactory<>("threadStats"));
+        timelineColumn.setCellFactory(param -> new TimelineCell());
     }
     
     @FXML
     private void onOpenBtnClick(ActionEvent event){
+        if (boundScrollBar != true) {
+            bindScroll();
+            boundScrollBar = true;
+        }
         FileChooser dialog = new FileChooser();
         dialog.setTitle("Choose HeapStats Thread Recorder file");
         dialog.setInitialDirectory(new File(HeapStatsUtils.getDefaultDirectory()));
@@ -90,20 +118,28 @@ public class ThreadRecorderController extends PluginController implements Initia
             TaskAdapter<ThreadRecordParseTask> task = new TaskAdapter<>(new ThreadRecordParseTask(recorderFile));
             super.bindTask(task);
             task.setOnSucceeded(evt -> {
-                                         ThreadRecordParseTask parser = task.getTask();
-                                         
-                                         ObservableList<ThreadStat> list = FXCollections.observableArrayList(parser.getThreadStatList());
-                                         startCombo.setItems(list);
-                                         endCombo.setItems(list);
-                                         startCombo.getSelectionModel().selectFirst();
-                                         endCombo.getSelectionModel().selectLast();
-                                         
-                                         Map<Long, String> idMap = parser.getIdMap();
-                                         threadListView.setItems(FXCollections.observableArrayList(idMap.keySet().stream()
-                                                                                                                 .sorted()
-                                                                                                                 .map(k -> new ThreadShowSwitch(k, idMap.get(k)))
-                                                                                                                 .collect(Collectors.toList())));
-                                       });
+                ThreadRecordParseTask parser = task.getTask();
+
+                ObservableList<ThreadStat> list = FXCollections.observableArrayList(parser.getThreadStatList());
+                startCombo.setItems(list);
+                endCombo.setItems(list);
+                startCombo.getSelectionModel().selectFirst();
+                endCombo.getSelectionModel().selectLast();
+
+                Map<Long, List<ThreadStat>> statById = list.stream()
+                        .collect(Collectors.groupingBy(ThreadStat::getId));
+
+                Map<Long, String> idMap = parser.getIdMap();
+                final LocalDateTime startTime = list.get(0).getTime();
+                final LocalDateTime endTime = list.get(list.size() - 1).getTime();
+                ObservableList<ThreadStatViewModel> threadStats = FXCollections.observableArrayList(idMap.keySet().stream()
+                                .sorted()
+                                .map(k -> new ThreadStatViewModel(k, idMap.get(k), startTime, endTime, statById.get(k)))
+                                .collect(Collectors.toList()));
+                adjustColumnWidth(startTime, endTime);
+                threadListView.setItems(threadStats);
+                timelineView.setItems(threadStats);
+            });
             
             Thread parseThread = new Thread(task);
             parseThread.start();
@@ -135,5 +171,53 @@ public class ThreadRecorderController extends PluginController implements Initia
     public Runnable getOnCloseRequest() {
         return null;
     }
-    
+
+    private void bindScroll() {
+        ScrollBar leftScrollBar = getVerticalScrollBar(threadListView);
+        ScrollBar rightScrollBar = getVerticalScrollBar(timelineView);
+        leftScrollBar.valueProperty().bindBidirectional(rightScrollBar.valueProperty());
+    }
+
+    private ScrollBar getVerticalScrollBar(TableView<?> tableView) {
+        Set<Node> nodes = tableView.lookupAll(".scroll-bar");
+        for (Node node : nodes) {
+            if (node instanceof ScrollBar) {
+                ScrollBar scrollBar = (ScrollBar) node;
+                if (scrollBar.getOrientation() == Orientation.VERTICAL) {
+                    return scrollBar;
+                }
+            }
+        }
+        throw new IllegalStateException("Not found ScrollBar.");
+    }
+
+    private void updateTime(LocalDateTime time, boolean start) {
+        if (timelineView.getItems().size() > 0) {
+            List<ThreadStatViewModel> updatedModels = timelineView.getItems().stream()
+                    .map(model -> {
+                        if (start) {
+                            model.setStartTime(time);
+                        } else {
+                            model.setEndTime(time);
+                        }
+                        return model;
+                    }).collect(Collectors.toList());
+            ObservableList<ThreadStatViewModel> newViewModels = FXCollections.observableArrayList(updatedModels);
+            threadListView.getItems().clear();
+            threadListView.setItems(newViewModels);
+            timelineView.getItems().clear();
+            timelineView.setItems(newViewModels);
+            LocalDateTime startTime = newViewModels.get(0).getStartTime();
+            LocalDateTime endTime = newViewModels.get(0).getEndTime();
+            adjustColumnWidth(startTime, endTime);
+        }
+    }
+
+    private void adjustColumnWidth(LocalDateTime startTime, LocalDateTime endTime) {
+        long timeDiff = startTime.until(endTime, ChronoUnit.MILLIS);
+        double newWidth = timeDiff * TimelineCell.LENGTH_PER_MILLS + TIMELINE_PADDING;
+        newWidth = (newWidth < DEFAULT_COLUMN_WIDTH) ? DEFAULT_COLUMN_WIDTH : newWidth;
+        timelineColumn.setPrefWidth(newWidth);
+    }
+
 }

--- a/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/ThreadStatViewModel.java
+++ b/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/ThreadStatViewModel.java
@@ -18,14 +18,20 @@
 package jp.co.ntt.oss.heapstats.plugin.builtin.threadrecorder;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
+import jp.co.ntt.oss.heapstats.container.threadrecord.ThreadStat;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 /**
- * This class uses for switch to show Thread Status Data.
+ * Thread Status Data Model for presentation.
  * 
  * @author Yasumasa Suenaga
  */
-public class ThreadShowSwitch {
+public class ThreadStatViewModel {
     
     private final BooleanProperty show;
     
@@ -33,9 +39,19 @@ public class ThreadShowSwitch {
     
     private String name;
 
-    public ThreadShowSwitch(long id, String name) {
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    private final ReadOnlyObjectWrapper<List<ThreadStat>> threadStats;
+
+    public ThreadStatViewModel(long id, String name, LocalDateTime startTime, LocalDateTime endTime,
+            List<ThreadStat> threadStats) {
         this.id = id;
         this.name = name;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.threadStats = new ReadOnlyObjectWrapper<>(threadStats);
         this.show = new SimpleBooleanProperty(true);
     }
     
@@ -58,5 +74,29 @@ public class ThreadShowSwitch {
     public void setName(String name) {
         this.name = name;
     }
-    
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public List<ThreadStat> getThreadStats() {
+        return threadStats.get();
+    }
+
+    public ReadOnlyObjectProperty<List<ThreadStat>> threadStatsProperty() {
+        return threadStats.getReadOnlyProperty();
+    }
+
 }

--- a/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/TimelineCell.java
+++ b/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/TimelineCell.java
@@ -1,0 +1,98 @@
+package jp.co.ntt.oss.heapstats.plugin.builtin.threadrecorder;
+
+import javafx.geometry.Pos;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.TableCell;
+import javafx.scene.layout.HBox;
+import javafx.scene.shape.Rectangle;
+import jp.co.ntt.oss.heapstats.container.threadrecord.ThreadStat;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Table cell for thread timeline.
+ */
+public class TimelineCell extends TableCell<ThreadStatViewModel, List<ThreadStat>> {
+
+    public static final double LENGTH_PER_MILLS = 1;
+
+    private static final double RECT_HEIGHT = 16;
+
+    private static final String CSS_CLASS_PREFIX = "rect-";
+
+    private final HBox container;
+
+    public TimelineCell() {
+        container = new HBox(0);
+        container.setAlignment(Pos.CENTER_LEFT);
+        setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+        setAlignment(Pos.CENTER_LEFT);
+    }
+
+    @Override
+    protected void updateItem(List<ThreadStat> item, boolean empty) {
+        super.updateItem(item, empty);
+        if (empty || item == null || item.isEmpty()) {
+            updateToEmptyCell();
+        } else {
+            ThreadStatViewModel viewModel = getTableView().getItems().get(getIndex());
+            LocalDateTime startTime = viewModel.getStartTime();
+            LocalDateTime endTime = viewModel.getEndTime();
+            if (startTime.isAfter(endTime)) {
+                updateToEmptyCell();
+            } else {
+                drawTimeline(startTime, item, endTime);
+            }
+        }
+    }
+
+    private void drawTimeline(LocalDateTime startTime, List<ThreadStat> item, LocalDateTime endTime) {
+        container.getChildren().clear();
+
+        LocalDateTime prevTime = startTime;
+        ThreadStat.ThreadEvent prevEvent = item.get(0).getEvent();
+        List<Rectangle> rects = new ArrayList<>();
+        for (int i = 0; i < item.size(); i++) {
+            ThreadStat threadStat = item.get(i);
+            LocalDateTime currentTime = threadStat.getTime();
+            boolean end = currentTime.isAfter(endTime);
+            currentTime = end ? endTime : currentTime;
+            if (i == 0 && threadStat.getEvent() == ThreadStat.ThreadEvent.ThreadStart) {
+                rects.add(createThreadRect(prevTime, currentTime, ThreadStat.ThreadEvent.Unused));
+            } else {
+                rects.add(createThreadRect(prevTime, currentTime, prevEvent));
+            }
+            if (end) {
+                break;
+            }
+            
+            prevTime = currentTime;
+            prevEvent = threadStat.getEvent();
+            
+            if (i == item.size() - 1 && threadStat.getEvent() != ThreadStat.ThreadEvent.ThreadEnd) {
+                rects.add(createThreadRect(prevTime, endTime, prevEvent));
+            }
+        }
+        container.getChildren().addAll(rects);
+        setGraphic(container);
+    }
+
+    private void updateToEmptyCell() {
+        setText(null);
+        setGraphic(null);
+    }
+
+    private Rectangle createThreadRect(LocalDateTime startTime, LocalDateTime endTime,
+                                       ThreadStat.ThreadEvent prevEvent) {
+        long timeDiff = startTime.until(endTime, ChronoUnit.MILLIS);
+        double width = LENGTH_PER_MILLS * timeDiff;
+        Rectangle rectangle = new Rectangle(width, RECT_HEIGHT);
+        String styleClass = CSS_CLASS_PREFIX + prevEvent.name().toLowerCase();
+        rectangle.getStyleClass().add(styleClass);
+        return rectangle;
+    }
+
+}

--- a/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/threadrecorder.css
+++ b/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/threadrecorder.css
@@ -1,0 +1,75 @@
+.rect-unused {
+    -fx-fill: transparent;
+}
+
+.rect-threadstart {
+    -fx-fill: #ff8c00;
+}
+
+.rect-threadend {
+    -fx-fill: transparent;
+}
+
+.rect-monitorwait {
+    -fx-fill: #ff00ff;
+}
+
+.rect-monitorwaited {
+    -fx-fill: #ff8c00;
+}
+
+.rect-monitorcontendedenter {
+    -fx-fill: #32cd32;
+}
+
+.rect-monitorcontendedentered {
+    -fx-fill: #ff8c00;
+}
+
+.rect-threadsleepstart {
+    -fx-fill: #87cefa;
+}
+
+.rect-threadsleepend {
+    -fx-fill: #ff8c00;
+}
+
+.rect-park {
+    -fx-fill: #9370db;
+}
+
+.rect-unpark {
+    -fx-fill: #ff8c00;
+}
+
+.rect-filewritestart {
+    -fx-fill: #ffd700;
+}
+
+.rect-filewriteend {
+    -fx-fill: #ff8c00;
+}
+
+.rect-filereadstart {
+    -fx-fill: #228b22;
+}
+
+.rect-filereadend {
+    -fx-fill: #ff8c00;
+}
+
+.rect-socketwritestart {
+    -fx-fill: #ff4500;
+}
+
+.rect-socketwriteend {
+    -fx-fill: #ff8c00;
+}
+
+.rect-socketreadstart {
+    -fx-fill: #808000;
+}
+
+.rect-socketreadend {
+    -fx-fill: #ff8c00;
+}

--- a/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/threadrecorder.fxml
+++ b/heapstats-analyzer/src/jp/co/ntt/oss/heapstats/plugin/builtin/threadrecorder/threadrecorder.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<AnchorPane id="AnchorPane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="jp.co.ntt.oss.heapstats.plugin.builtin.threadrecorder.ThreadRecorderController">
+<AnchorPane id="AnchorPane" prefHeight="600.0" prefWidth="800.0" stylesheets="@threadrecorder.css" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="jp.co.ntt.oss.heapstats.plugin.builtin.threadrecorder.ThreadRecorderController">
    <children>
       <Button fx:id="openBtn" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#onOpenBtnClick" text="Recorder File" AnchorPane.leftAnchor="14.0" AnchorPane.topAnchor="14.0" />
       <TextField fx:id="fileNameBox" layoutX="118.0" layoutY="14.0" prefHeight="25.0" prefWidth="666.0" AnchorPane.leftAnchor="120.0" AnchorPane.rightAnchor="14.0" AnchorPane.topAnchor="14.0" />
@@ -21,10 +21,10 @@
           <TableColumn fx:id="threadNameColumn" editable="false" prefWidth="166.0" text="Thread" />
         </columns>
       </TableView>
-      <ScrollPane layoutX="261.0" layoutY="91.0" prefHeight="498.0" prefWidth="525.0" AnchorPane.bottomAnchor="14.0" AnchorPane.leftAnchor="261.0" AnchorPane.rightAnchor="14.0" AnchorPane.topAnchor="91.0">
-        <content>
-          <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="200.0" prefWidth="200.0" />
-        </content>
-      </ScrollPane>
+      <TableView fx:id="timelineView" layoutX="261.0" layoutY="91.0" prefHeight="495.0" prefWidth="527.0" AnchorPane.bottomAnchor="14.0" AnchorPane.leftAnchor="261.0" AnchorPane.rightAnchor="14.0" AnchorPane.topAnchor="91.0">
+        <columns>
+          <TableColumn fx:id="timelineColumn" maxWidth="1.7976931348623157E308" minWidth="200.0" prefWidth="525.0" />
+        </columns>
+      </TableView>
    </children>
 </AnchorPane>


### PR DESCRIPTION
ThreadRecorder のスレッドタイムライン部分の基本的な実装となります。

* 実装したこと
    - Java のスレッドを縦軸に並べ、横軸に時刻に応じたスレッドの状態を色分けして表示する
    - コンボボックスに表示される開始、終了時刻の範囲内で表示する
* 実装していないこと
    - 時刻目盛りの表示
    - スレッド名テーブルのチェックボックスクリックによる表示制御
    - 色の凡例表示
    - 色分けされているスレッド状態の情報をツールチップ等で表示する
* 制限事項
    - タイムライン表示の長さは 1 ミリ秒 = 1px 決めうちにしている
* 実装方法
    - TableView をスレッド一覧の横にもう一つ並べ、タイムラインの描画は TableCell 実装 (TimelineCell) の中で行っている。
    - 左右の Table に渡す ThreadViewModel というプレゼンテーションモデルクラスを作っている。
        + このモデルがスレッド名や開始・終了時刻、スレッドに応じたイベントリストを保持している。
        + ThreadShowSwitch クラスをリネームして作っている。
    - タイムラインは Rectangle を HBox に詰め込むことで描画している。
        + 全体の開始・終了時刻に満たない部分が透明の Rectangle を詰めている。
        + Rectangle の色は CSS に定義している。
            - CSS のクラス名とイベント名を合わせるという少しトリッキーな実装になっているので注意。
            - イベントは開始・終了がペアになっているという前提にしている。そのため、終了イベントに対応する色は、ThreadStart に対応する色になっている。

![2015-06-07 16 55 25](https://cloud.githubusercontent.com/assets/735573/8023245/02be13be-0d3d-11e5-8863-70845c4cdbd0.png)
![2015-06-07 16 56 14](https://cloud.githubusercontent.com/assets/735573/8023247/19008f80-0d3d-11e5-8734-5f62e1fca2eb.png)
